### PR TITLE
Rename JUPYTERHUB_BASE_URL => OC_JUPYTERHUB_URL

### DIFF
--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -16,7 +16,7 @@ girder_api_key = os.environ.get('GIRDER_API_KEY')
 girder_token = os.environ.get('GIRDER_TOKEN')
 app_base_url = os.environ.get('APP_BASE_URL')
 cluster_id = os.environ.get('CLUSTER_ID')
-jupyterhub_base_url = os.environ.get('JUPYTERHUB_BASE_URL')
+jupyterhub_url = os.environ.get('OC_JUPYTERHUB_URL')
 
 if girder_host:
     girder_client = GirderClient(host=girder_host, port=girder_port,
@@ -27,7 +27,7 @@ if girder_host:
     elif girder_token is not None:
         girder_client.token = girder_token
 
-girder_file = lookup_file(girder_client, jupyterhub_base_url)
+girder_file = lookup_file(girder_client, jupyterhub_url)
 
 # TODO Need to use basis and theory
 def _fetch_calculation(molecule_id, type_=None, basis=None, theory=None, functional=None):

--- a/openchemistry/utils.py
+++ b/openchemistry/utils.py
@@ -5,7 +5,7 @@ import re
 from IPython.lib import kernel
 
 
-def lookup_file(girder_client, jupyterhub_base_url):
+def lookup_file(girder_client, jupyterhub_url):
     """
     Utility function to lookup the Girder file that the current notebook is running
     from.
@@ -16,11 +16,11 @@ def lookup_file(girder_client, jupyterhub_base_url):
     kernel_id = re.search('kernel-(.*).json', connection_file_path).group(1)
 
     # Authenticate with jupyterhub so we can get the cookie
-    r = requests.post('%s/hub/login' % jupyterhub_base_url, data={'Girder-Token': girder_client.token}, allow_redirects=False)
+    r = requests.post('%s/hub/login' % jupyterhub_url, data={'Girder-Token': girder_client.token}, allow_redirects=False)
     r.raise_for_status()
     cookies = r.cookies
 
-    url = "%s/user/%s/api/sessions" % (jupyterhub_base_url, login)
+    url = "%s/user/%s/api/sessions" % (jupyterhub_url, login)
     r = requests.get(url, cookies=cookies)
     r.raise_for_status()
 
@@ -31,7 +31,7 @@ def lookup_file(girder_client, jupyterhub_base_url):
     name = os.path.basename(path)
 
     # Logout
-    url = "%s/hub/logout" % jupyterhub_base_url
+    url = "%s/hub/logout" % jupyterhub_url
     r = requests.get(url, cookies=cookies)
 
 


### PR DESCRIPTION
The latest version of JupyterHub has introduced its own JUPYTERHUB_BASE_URL with a subtly different meaning. Its not really a URL its more of a prefix.