### PR TITLE
Move jupyterlab_cjson python code to openchemistrypy 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .project
 .pydevproject
 examples/.ipynb_checkpoints/
-openchemistrypy.egg-info/
+openchemistry.egg-info/
+.eggs/

--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -302,7 +302,7 @@ class Structure(object):
     def show(self, style='ball-stick'):
 
         try:
-            from jupyterlab_cjson import CJSON
+            from .notebook import CJSON
             if self._calculation_result:
                 return CJSON(self._calculation_result._cjson, vibrational=False)
             else:
@@ -328,7 +328,7 @@ class Frequencies(object):
 
     def show(self, mode=None, animate_modes=False, spectrum=True):
         try:
-            from jupyterlab_cjson import CJSON
+            from .notebook import CJSON
             return CJSON(self._calculation_result._cjson, structure=animate_modes,
                          animate_mode=mode)
         except ImportError:
@@ -394,7 +394,7 @@ class Orbitals(object):
 
     def show(self, mo='homo', iso=None):
         try:
-            from jupyterlab_cjson import CJSON
+            from .notebook import CJSON
 
             cjson_copy = self._cjson.copy()
             cjson_copy['cube'] = self._calculate_mo(mo)
@@ -542,7 +542,7 @@ class AttributeInterceptor(object):
 class PendingCalculationResultWrapper(AttributeInterceptor):
     def __init__(self, calculation, taskflow_id=None):
         try:
-            from jupyterlab_cjson import CalculationMonitor
+            from .notebook import CalculationMonitor
             if taskflow_id is None:
                 taskflow_id = calculation.properties['taskFlowId']
 
@@ -761,7 +761,7 @@ def show_free_energies(reactions, basis=None, theory=None, functional=None):
         taskflow_ids = list(set(taskflow_ids))
 
         try:
-            from jupyterlab_cjson import CalculationMonitor
+            from .notebook import CalculationMonitor
             table = CalculationMonitor({
                     'taskFlowIds': taskflow_ids,
                     'girderToken': girder_client.token
@@ -773,7 +773,7 @@ def show_free_energies(reactions, basis=None, theory=None, functional=None):
         return table;
 
     try:
-        from jupyterlab_cjson import FreeEnergy
+        from .notebook import FreeEnergy
 
         return FreeEnergy(free_energy_chart_data)
     except ImportError:

--- a/openchemistry/notebook.py
+++ b/openchemistry/notebook.py
@@ -1,0 +1,93 @@
+from IPython.display import display, JSON, DisplayObject
+
+# A display class that can be used within a notebook.
+#   from openchemistry.notebook import CJSON
+#   CJSON(data)
+
+DEFAULT_ISO = 43 / 2000.0;
+DEFAULT_ISO_SURFACES = [{
+    'value': DEFAULT_ISO,
+    'color': 'blue',
+    'opacity': 0.9,
+  }, {
+    'value': -DEFAULT_ISO,
+    'color': 'red',
+    'opacity': 0.9
+  }]
+
+class CJSON(JSON):
+    """A display class for displaying CJSON visualizations in the Jupyter Notebook and IPython kernel.
+    CJSON expects a JSON-able dict, not serialized JSON strings.
+    Scalar types (None, number, string) are not allowed, only dict containers.
+    """
+
+
+
+    def __init__(self, data=None, url=None, filename=None, vibrational=True, structure=True,
+                 iso_surfaces=DEFAULT_ISO_SURFACES, animate_mode=None, calculation_id=None,
+                 mo=None):
+        super(CJSON, self).__init__(data, url, filename)
+        self.metadata['vibrational'] = vibrational
+        self.metadata['structure'] = structure
+        self.metadata['isoSurfaces'] = iso_surfaces
+        self.metadata['animateMode'] = animate_mode
+        self.metadata['mo'] = mo
+        self.metadata['calculationId'] = calculation_id
+
+    def _ipython_display_(self):
+        bundle = {
+            'application/cjson+json': self.data,
+            'text/plain': '<jupyterlab_cjson.CJSON object>'
+        }
+        metadata = {
+            'application/cjson+json': self.metadata
+        }
+        display(bundle, metadata=metadata, raw=True)
+
+class FreeEnergy(JSON):
+    """A display class for displaying free energy visualizations in the Jupyter Notebook and IPython kernel.
+    FreeEnergy expects a JSON-able dict.
+    """
+
+    def __init__(self, data=None, url=None, filename=None):
+        super(FreeEnergy, self).__init__(data, url, filename)
+
+    def _ipython_display_(self):
+        bundle = {
+            'application/cjson-free_energy+json': self.data,
+            'text/plain': '<jupyterlab_cjson.FreeEnergy object>'
+        }
+        metadata = {
+            'application/cjson-free_energy+json': self.metadata
+        }
+        display(bundle, metadata=metadata, raw=True)
+
+class CalculationMonitor(DisplayObject):
+    """
+    A display class for monitoring calculations Jupyter Notebook and IPython kernel.
+    """
+
+    def __init__(self, data=None, url=None, filename=None):
+        super(CalculationMonitor, self).__init__(data, url, filename)
+
+    def _ipython_display_(self):
+        bundle = {
+            'application/calculation+json': self.data,
+            'text/plain': '<jupyterlab_cjson.CalculationMonitor object>'
+        }
+        metadata = {
+            'application/calculation+json': {}
+        }
+        display(bundle, metadata=metadata, raw=True)
+
+    def __getattr__(self, name):
+        # This is a little fragile, it seem that ipython is looking for the
+        # absence of _ipython_canary_method_should_not_exist_, so only return
+        # self for 'public' methods.
+        if name[0] != '_':
+            return self
+        else:
+            return DisplayObject.__getattr__(self, name)
+
+    def __call__(self):
+        return self


### PR DESCRIPTION
Notebook related python code is now under `openchemistry.notebook`

Related to https://github.com/OpenChemistry/jupyterlab_cjson/issues/11

![screenshot_2018-11-16 jupyterlab](https://user-images.githubusercontent.com/15913822/48638539-ec198480-e99e-11e8-869e-c3546b782b72.png)
