### PR TITLE
Added a function to set the name of a molecule

### DIFF
--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -282,6 +282,12 @@ class GirderMolecule(Molecule):
         params.update(input_parameters)
         return self.calculate(image_name, params, input_geometry, run_parameters, force)
 
+    def set_name(self, name):
+        body = {
+            'name': name
+        }
+        girder_client.patch('molecules/%s' % self._id, json=body)
+
 class CalculationResult(Molecule):
 
     def __init__(self, _id=None, properties=None, molecule_id=None):


### PR DESCRIPTION
With the GirderMolecule object, one can call
`set_name()` to change the name of the molecule.

This PR goes along with [this PR](https://github.com/OpenChemistry/mongochemserver/pull/117).

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>