### PR TITLE
Added methods to get data for structure and calcs

### DIFF
--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -455,6 +455,10 @@ class Visualization(ABC):
             else:
                 print(alt)
 
+    @abstractmethod
+    def data(self):
+        return self._provider.cjson
+
     def url(self):
         url = self._provider.url
         if url is None:
@@ -513,10 +517,16 @@ class Structure(Visualization):
     def show(self, viewer='moljs', menu=True, **kwargs):
         return super(Structure, self).show(viewer=viewer, menu=menu, **kwargs)
 
+    def data(self):
+        return self._provider.cjson
+
 class Vibrations(Visualization):
 
     def show(self, viewer='moljs', spectrum=True, menu=True, mode=-1, play=True, **kwargs):
         return super(Vibrations, self).show(viewer=viewer, spectrum=spectrum, menu=menu, mode=mode, play=play, **kwargs)
+
+    def data(self):
+        return self._provider.vibrations
 
     def table(self):
         vibrations = self._provider.vibrations
@@ -566,6 +576,9 @@ class Orbitals(Visualization):
         self._provider.load_orbital(mo)
         return super(Orbitals, self).show(viewer=viewer, volume=volume, isosurface=isosurface, menu=menu, mo=mo, iso=iso, transfer_function=transfer_function)
 
+    def data(self):
+        return self._provider.cjson
+
 class Properties(Visualization):
 
     def show(self, **kwargs):
@@ -578,6 +591,9 @@ class Properties(Visualization):
         except ImportError:
             # Outside notebook print CJSON
             print(properties)
+
+    def data(self):
+        return self._provider.cjson.get('properties', {})
 
     def _md_table(self, properties):
         import math

--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -296,6 +296,9 @@ class CalculationResult(Molecule):
         self._properties = properties
         self._molecule_id = molecule_id
 
+    def data(self):
+        return self._provider.cjson
+
     @property
     def frequencies(self):
         import warnings
@@ -577,7 +580,12 @@ class Orbitals(Visualization):
         return super(Orbitals, self).show(viewer=viewer, volume=volume, isosurface=isosurface, menu=menu, mo=mo, iso=iso, transfer_function=transfer_function)
 
     def data(self):
-        return self._provider.cjson
+        whitelist = ['orbitals', 'properties']
+        output = {}
+        for item in whitelist:
+            output[item] = self._provider.cjson[item]
+
+        return output
 
 class Properties(Visualization):
 


### PR DESCRIPTION
These are used in the same places `show()` is normally used, but `data()` is used instead. If the calculation has not been performed, it even runs the calculation as if you had used `show()` instead. Some examples are shown below.

**Structure Data**
![Screenshot from 2019-03-28 08-17-20](https://user-images.githubusercontent.com/9558430/55157628-45ef3f80-5133-11e9-846e-d2259cd3b943.png)

**Vibrations Data**
![Screenshot from 2019-03-28 08-29-19](https://user-images.githubusercontent.com/9558430/55157769-a1b9c880-5133-11e9-8bba-66b2f9f92bb4.png)

**Properties Data** (from chemml, for instance)
![Screenshot from 2019-03-28 08-20-43](https://user-images.githubusercontent.com/9558430/55157682-6ae3b280-5133-11e9-9da9-d20a6280489d.png)

**Orbital Data**
![Screenshot from 2019-03-28 08-31-23](https://user-images.githubusercontent.com/9558430/55157881-ecd3db80-5133-11e9-95f5-adcbb0e733b2.png)


The orbital data includes a lot of information in it, including the structural cjson such as atom positions (we can remove those if needed). But you can extract its parts using the keys to the dictionary (some examples below).

**Basis Set from Orbital Data**
![Screenshot from 2019-03-28 08-22-45](https://user-images.githubusercontent.com/9558430/55157932-14c33f00-5134-11e9-978b-690c054f6bf0.png)

**Orbitals from Orbital Data**
![Screenshot from 2019-03-28 08-21-31](https://user-images.githubusercontent.com/9558430/55157989-33c1d100-5134-11e9-98f1-479471ca39f6.png)


Signed-off-by: Patrick Avery <patrick.avery@kitware.com>