### PR TITLE
Make importing an inchi more intuitive

### DIFF
--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -689,6 +689,11 @@ def _find_using_cactus(identifier):
 
 def import_structure(smiles=None, inchi=None, cjson=None):
 
+    # If the smiles begins with 'InChI=', then it is actually an inchi instead
+    if smiles and smiles.startswith('InChI='):
+        inchi = smiles
+        smiles = None
+
     params = {}
     if smiles:
         params['smiles'] = smiles


### PR DESCRIPTION
This allows the user to write something like
`import_structure('InChI=1S/H2O/h1H2')`, and the function
will interpret it as an InChI instead of a SMILES.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>