### PR TITLE
Update GET /molecules API to match new structure

### DIFF
--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -57,10 +57,10 @@ def _find_molecule_using_cactus(identifier):
     params = {
         'cactus': identifier
     }
-    molecules = GirderClient().get('molecules/search', parameters=params)
+    res = GirderClient().get('molecules/search', parameters=params)
     # Just pick the first
-    if len(molecules) > 0:
-        return molecules[0]
+    if 'results' in res and len(res['results']) > 0:
+        return res['results'][0]
     else:
         return None
 

--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -65,9 +65,9 @@ def _find_molecule_using_cactus(identifier):
         return None
 
 def _find_molecule_using_girder(params):
-    molecules = GirderClient().get('molecules', parameters=params)
-    if len(molecules) > 0:
-        return molecules[0]
+    res = GirderClient().get('molecules', parameters=params)
+    if 'results' in res and len(res['results']) > 0:
+        return res['results'][0]
     else:
         return None
 


### PR DESCRIPTION
The GET /molecules results are now returned like so:
```
{
  "limit": 25,
  "matches": 3,
  "offset": 0,
  "results": [...]
}
```

Update our code to reflect those changes.

This PR goes along with [this one](https://github.com/OpenChemistry/mongochemserver/pull/124).