### PR TITLE
Make 3D Coordinate Generation Optional for `import_structure`

### DIFF
--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -1,3 +1,3 @@
 from ._utils import hash_object, camel_to_space, parse_image_name
 from .io import Psi4Reader, NWChemJsonReader, CjsonReader
-from .api import load, find_structure, find_calculation, find_molecule, monitor, queue, find_spectra
+from .api import load, find_structure, find_calculation, find_molecule, monitor, queue, find_spectra, import_structure

--- a/openchemistry/_data.py
+++ b/openchemistry/_data.py
@@ -75,6 +75,16 @@ class MoleculeProvider(CjsonProvider):
     def __init__(self, cjson, molecule_id):
         super(MoleculeProvider, self).__init__(cjson)
         self._id = molecule_id
+        self._svg_ = None
+
+    @property
+    def svg(self):
+        if self._svg_ is None:
+            resp = GirderClient().get('molecules/%s/svg' % self._id,
+                                      jsonResp=False)
+            self._svg_ = resp.content.decode('utf-8')
+
+        return self._svg_
 
     @property
     def url(self):

--- a/openchemistry/_notebook.py
+++ b/openchemistry/_notebook.py
@@ -1,4 +1,4 @@
-from IPython.display import display, JSON, DisplayObject
+from IPython.display import display, JSON, DisplayObject, SVG
 
 class CJSON(JSON):
     """A display class for displaying CJSON visualizations in the Jupyter Notebook and IPython kernel.

--- a/openchemistry/_utils.py
+++ b/openchemistry/_utils.py
@@ -133,3 +133,10 @@ def parse_image_name(image_name):
         repository, tag = split
 
     return repository, tag
+
+def cjson_has_3d_coords(cjson):
+    coords = parse('atoms.coords').find(cjson)
+    if (coords and '3d' in coords[0].value and
+        len(coords[0].value['3d']) > 0):
+        return True
+    return False

--- a/openchemistry/_visualization.py
+++ b/openchemistry/_visualization.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import urllib.parse
 
-from ._utils import hash_object, camel_to_space
+from ._utils import hash_object, camel_to_space, cjson_has_3d_coords
 
 class Visualization(ABC):
     def __init__(self, provider):
@@ -22,6 +22,15 @@ class Visualization(ABC):
             'play': play,
             **self._transfer_function_to_params(transfer_function)
         }
+
+        # Show SVG if 3D coords are not available
+        if not cjson_has_3d_coords(self._provider.cjson):
+            try:
+                from ._notebook import SVG
+                return SVG(self._provider.svg)
+            except ImportError:
+                print(self._provider.svg)
+
         try:
             from ._notebook import CJSON
             return CJSON(self._provider.cjson, **self._params)

--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -85,7 +85,7 @@ def _calculation_monitor(taskflow_ids):
 
     return table
 
-def import_structure(smiles=None, inchi=None, cjson=None):
+def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True):
     # If the smiles begins with 'InChI=', then it is actually an inchi instead
     if smiles and smiles.startswith('InChI='):
         inchi = smiles
@@ -101,6 +101,7 @@ def import_structure(smiles=None, inchi=None, cjson=None):
     else:
         raise Exception('SMILES, InChI, or CJson must be provided')
 
+    params['generate3D'] = gen3d
     molecule = GirderClient().post('molecules', json=params)
 
     if not molecule:

--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -106,7 +106,7 @@ def import_structure(smiles=None, inchi=None, cjson=None):
     if not molecule:
         raise Exception('Molecule could not be imported with params', params)
 
-    return GirderMolecule(molecule['_id'], molecule['cjson'])
+    return GirderMolecule(molecule['_id'], molecule.get('cjson'))
 
 def find_molecule(identifier=None, inchi=None, smiles=None):
     molecule = _find_molecule(identifier, inchi, smiles)


### PR DESCRIPTION
This PR depends on [this one](https://github.com/OpenChemistry/mongochemserver/pull/116). Currently, if you try to show a molecule that does not have 3D coordinates in the jupyter notebook, it is just blank. We should make it so that the 2D SVG is shown instead.