### PR TITLE
Check all molecules for 3D coords in batch job

### DIFF
--- a/openchemistry/_calculation.py
+++ b/openchemistry/_calculation.py
@@ -31,11 +31,12 @@ class GirderMolecule(Molecule):
 
     def calculate(self, image_name, input_parameters, input_geometry=None, run_parameters=None, force=False):
         molecule_id = self._id
-        calculation = _fetch_or_submit_calculations([molecule_id], image_name,
-                                                    input_parameters,
-                                                    [input_geometry],
-                                                    run_parameters, force)[0]
-        return _calculation_result(calculation, molecule_id)
+        calculations = _fetch_or_submit_calculations([molecule_id], image_name,
+                                                     input_parameters,
+                                                     [input_geometry],
+                                                     run_parameters, force)
+        if calculations:
+            return _calculation_result(calculations[0], molecule_id)
 
     def energy(self, image_name, input_parameters, input_geometry=None, run_parameters=None, force=False):
         params = {'task': 'energy'}
@@ -252,7 +253,11 @@ def _fetch_or_submit_calculations(molecule_ids, image_name, input_parameters,
                                   input_geometries=None, run_parameters=None,
                                   force=False):
 
-    _check_required_coords(molecule_ids, image_name)
+    try:
+        _check_required_coords(molecule_ids, image_name)
+    except Exception as e:
+        print(str(e))
+        return []
 
     if input_geometries is None:
         input_geometries = [None] * len(molecule_ids)


### PR DESCRIPTION
This is a better place to check if the molecules all have 3D
coordinates, and it is less error prone. It will submit all
3D coordinate generations in one go rather than the user having
to re-run the function to start each individual one.

It also avoids creating pending calculations until all molecules
have 3D coordinates.