### PR TITLE
Run calculations on geometries

### DIFF
--- a/openchemistry/_calculation.py
+++ b/openchemistry/_calculation.py
@@ -59,6 +59,9 @@ class GirderMolecule(Molecule):
         }
         GirderClient().patch('molecules/%s' % self._id, json=body)
 
+    def add_geometry(self, cjson):
+        GirderClient().post('molecules/%s/geometries' % self._id, json=cjson)
+
 class CalculationResult(Molecule):
 
     def __init__(self, _id=None, properties=None, molecule_id=None):

--- a/openchemistry/_data.py
+++ b/openchemistry/_data.py
@@ -87,6 +87,11 @@ class MoleculeProvider(CjsonProvider):
         return self._svg_
 
     @property
+    def geometries(self):
+        resp = GirderClient().get('molecules/%s/geometries' % self._id)
+        return resp.get('results', [])
+
+    @property
     def url(self):
         return '%s/molecules/%s' % (GirderClient().app_url.rstrip('/'), self._id)
 

--- a/openchemistry/_molecule.py
+++ b/openchemistry/_molecule.py
@@ -1,4 +1,6 @@
-from ._visualization import Structure, Orbitals, Properties, Vibrations
+from ._visualization import (
+    Structure, Orbitals, Properties, Vibrations, Geometries
+)
 
 class Molecule(object):
     def __init__(self, provider):
@@ -7,7 +9,8 @@ class Molecule(object):
             'structure': None,
             'orbitals': None,
             'properties': None,
-            'vibrations': None
+            'vibrations': None,
+            'geometries': None
         }
 
     @property
@@ -33,3 +36,9 @@ class Molecule(object):
         if self._visualizations['vibrations'] is None:
             self._visualizations['vibrations'] = Vibrations(self._provider)
         return self._visualizations['vibrations']
+
+    @property
+    def geometries(self):
+        if self._visualizations['geometries'] is None:
+            self._visualizations['geometries'] = Geometries(self._provider)
+        return self._visualizations['geometries']

--- a/openchemistry/_visualization.py
+++ b/openchemistry/_visualization.py
@@ -203,3 +203,40 @@ class Properties(Visualization):
             )
 
         return table
+
+class Geometries(Visualization):
+
+    def show(self, **kwargs):
+        geometries = self._provider.geometries
+        try:
+            from IPython.display import Markdown
+            table = self._md_table(geometries)
+            return Markdown(table)
+        except ImportError:
+            # Outside notebook print CJSON
+            print(geometries)
+
+    def data(self):
+        return self._provider.geometries
+
+    def _md_table(self, geometries):
+        import math
+        table = '''### Geometries
+| Id | Provenance | Energy |
+|----|------------|--------|'''
+
+        for geometry in geometries:
+            id = geometry.get('_id')
+            provenance = geometry.get('provenanceType')
+            try:
+                energy = float(geometry.get('energy', math.nan))
+            except ValueError:
+                energy = math.nan
+
+            table += '\n| %s | %s | %.2f |' % (
+                id,
+                provenance,
+                energy
+            )
+
+        return table

--- a/taskflows/taskflows/__init__.py
+++ b/taskflows/taskflows/__init__.py
@@ -360,6 +360,7 @@ def setup_input(task, input_, cluster, image, run_parameters, root_folder, conta
     calculation_ids = calculation_ids[0].value
     calculations = [client.get('calculations/%s' % x) for x in calculation_ids]
     molecule_ids = [x['moleculeId'] for x in calculations]
+    geometry_ids = [x.get('geometryId') for x in calculations]
 
     input_parameters = [x.get('input', {}).get('parameters', {})
                         for x in calculations]
@@ -378,9 +379,16 @@ def setup_input(task, input_, cluster, image, run_parameters, root_folder, conta
 
     # Fetch the starting geometries
     geometry_data = []
-    for molecule_id in molecule_ids:
-        r = client.get('molecules/%s/%s' % (molecule_id, input_format),
-                       jsonResp=False)
+    for molecule_id, geometry_id in zip(molecule_ids, geometry_ids):
+
+        path = 'molecules/%s/' % molecule_id
+        if geometry_id:
+            # It is preferred to use the geometry if we have it
+            path += 'geometries/%s/' % geometry_id
+
+        path += '%s' % input_format
+
+        r = client.get(path, jsonResp=False)
 
         if r.status_code != 200:
             raise Exception('Failed to get molecule in format: ' + input_format)


### PR DESCRIPTION
This allows the user to specify a geometry when running a
calculation on a molecule.

Currently, the user specifies the geometry using the mongodb id.
It would probably be better to come up with a more user-friendly
identification system that maps to the mongodb ids.

![Screenshot from 2019-09-04 07-29-04](https://user-images.githubusercontent.com/9558430/64251741-3268b180-cee7-11e9-93d1-5c0ce9c29f64.png)
![Screenshot from 2019-09-04 07-41-15](https://user-images.githubusercontent.com/9558430/64251846-6e037b80-cee7-11e9-907a-a893cd884e1e.png)

Depends on [this PR](https://github.com/OpenChemistry/mongochemserver/pull/112).