### PR TITLE
Add ability to specify gen3d forcefield and steps

### DIFF
--- a/openchemistry/_data.py
+++ b/openchemistry/_data.py
@@ -83,17 +83,7 @@ class MoleculeProvider(CjsonProvider):
     def cjson(self):
         if self._cjson_ is None:
             # Try to update the cjson
-            try:
-                resp = GirderClient().get('molecules/%s/cjson' % self._id)
-            except HttpError as e:
-                fail_str = 'Molecule does not have 3D coordinates.'
-                if fail_str in e.responseText:
-                    # No 3D coordinates...
-                    return None
-
-                raise
-
-            self._cjson_ = resp
+            self._cjson_ = GirderClient().get('molecules/%s/cjson' % self._id)
 
         return self._cjson_
 

--- a/openchemistry/_data.py
+++ b/openchemistry/_data.py
@@ -80,6 +80,24 @@ class MoleculeProvider(CjsonProvider):
         self._svg_ = None
 
     @property
+    def cjson(self):
+        if self._cjson_ is None:
+            # Try to update the cjson
+            try:
+                resp = GirderClient().get('molecules/%s/cjson' % self._id)
+            except HttpError as e:
+                fail_str = 'Molecule does not have 3D coordinates.'
+                if fail_str in e.responseText:
+                    # No 3D coordinates...
+                    return None
+
+                raise
+
+            self._cjson_ = resp
+
+        return self._cjson_
+
+    @property
     def svg(self):
         if self._svg_ is None:
             resp = GirderClient().get('molecules/%s/svg' % self._id,

--- a/openchemistry/_visualization.py
+++ b/openchemistry/_visualization.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import urllib.parse
 
+from ._girder import GirderClient
 from ._utils import hash_object, camel_to_space, cjson_has_3d_coords
 
 class Visualization(ABC):
@@ -119,6 +120,22 @@ class Structure(Visualization):
 
     def data(self):
         return self._provider.cjson
+
+    def generate_3d(self, forcefield='mmff94', steps=100):
+        if cjson_has_3d_coords(self._provider.cjson):
+            raise Exception('Molecule already has 3D coordinates')
+
+        id = self._provider._id
+        params = {
+            'gen3dForcefield': forcefield,
+            'gen3dSteps': steps
+        }
+
+        GirderClient().post('/molecules/%s/3d' % id, parameters=params)
+        print('Generating 3D coordinates...')
+
+        # Remove the cjson so it will update
+        self._provider._cjson_ = None
 
 class Vibrations(Visualization):
 

--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -88,7 +88,8 @@ def _calculation_monitor(taskflow_ids):
 
     return table
 
-def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True):
+def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True,
+                     gen3d_forcefield='mmff94', gen3d_steps=100):
     # If the smiles begins with 'InChI=', then it is actually an inchi instead
     if smiles and smiles.startswith('InChI='):
         inchi = smiles
@@ -105,6 +106,8 @@ def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True):
         raise Exception('SMILES, InChI, or CJson must be provided')
 
     params['generate3D'] = gen3d
+    params['gen3dForcefield'] = gen3d_forcefield
+    params['gen3dSteps'] = gen3d_steps
     molecule = GirderClient().post('molecules', json=params)
 
     if not molecule:


### PR DESCRIPTION
There are two ways to do this:

1. Using `oc.import_structure()`. If the structure does not have 3D
   coordinates, the forcefield and steps options may be set with the
   arguments `gen3d_forcefield` and `gen3d_steps`, respectively.
2. If a molecule does not have 3D coordinates, but is already in the
   database, 3D coordinates may be generated via
   `mol.structure.generate_3d()`, and `forcefield` and `steps` options
   can be passed to this function as well.

Note that `generate_3d()` can only be ran once per molecule in the database.
It cannot be ran for molecules that already have 3D coordinates.