### PR TITLE
Add a way to get optimized geometry IDs

### DIFF
--- a/openchemistry/_calculation.py
+++ b/openchemistry/_calculation.py
@@ -72,9 +72,22 @@ class CalculationResult(Molecule):
         self._id = _id
         self._properties = properties
         self._molecule_id = molecule_id
+        self._optimized_geometry_id = None
 
     def data(self):
         return self._provider.cjson
+
+    @property
+    def optimized_geometry_id(self):
+        if not self._optimized_geometry_id:
+            # Try to get it...
+            result = GirderClient().get('calculations/%s' % self._id)
+            if 'optimizedGeometryId' in result:
+                self._optimized_geometry_id = result['optimizedGeometryId']
+            else:
+                print('None')
+
+        return self._optimized_geometry_id
 
     @property
     def frequencies(self):


### PR DESCRIPTION
With a CalculationResult object (normally, they are named `result` in
the notebook examples), you can now call the property
`.optimized_geometry_id` on it to attempt to get the optimized geometry
ID. If the optimized geometry ID is found, it will be returned.

Only optimization tasks will have an optimized geometry ID. All others
will print 'None' and return None.