### PR TITLE
Accept parameters for creating a molecule from a notebook

### DIFF
--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -88,12 +88,14 @@ def _calculation_monitor(taskflow_ids):
 
     return table
 
-def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True, params={}):
+def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True, params=None):
     # If the smiles begins with 'InChI=', then it is actually an inchi instead
     if smiles and smiles.startswith('InChI='):
         inchi = smiles
         smiles = None
 
+    if params is None:
+        params = {}
     if smiles:
         params['smiles'] = smiles
     elif inchi:

--- a/openchemistry/api.py
+++ b/openchemistry/api.py
@@ -88,13 +88,12 @@ def _calculation_monitor(taskflow_ids):
 
     return table
 
-def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True):
+def import_structure(smiles=None, inchi=None, cjson=None, gen3d=True, params={}):
     # If the smiles begins with 'InChI=', then it is actually an inchi instead
     if smiles and smiles.startswith('InChI='):
         inchi = smiles
         smiles = None
 
-    params = {}
     if smiles:
         params['smiles'] = smiles
     elif inchi:


### PR DESCRIPTION
Users may optionally pass in parameters when importing a molecule in a notebook,
allowing them to set fields like 'name' and 'wikipediaUrl'.

![notebook_mol_params](https://user-images.githubusercontent.com/51238406/71996802-d2727680-320a-11ea-8ded-1e2e5590fda2.png)
