### PR TITLE
Add ability to calculate rmsd

### DIFF
--- a/openchemistry/__init__.py
+++ b/openchemistry/__init__.py
@@ -1,4 +1,6 @@
-from ._utils import hash_object, camel_to_space, parse_image_name
+from ._utils import (
+    hash_object, camel_to_space, parse_image_name, calculate_rmsd
+)
 from .io import Psi4Reader, NWChemJsonReader, CjsonReader, OrcaReader
 from .api import (
     load, find_structure, find_calculation, find_molecule, monitor, queue,

--- a/openchemistry/_utils.py
+++ b/openchemistry/_utils.py
@@ -5,6 +5,8 @@ import json
 import hashlib
 
 import avogadro
+import rmsd
+import numpy as np
 
 from jsonpath_rw import parse
 from IPython.lib import kernel
@@ -147,3 +149,57 @@ def cjson_has_3d_coords(cjson):
 def mol_has_3d_coords(mol):
     # This functions properly if passed None
     return cjson_has_3d_coords(mol.get('cjson'))
+
+def calculate_rmsd(mol_id1, mol_id2=None, geometry_id1=None, geometry_id2=None,
+                   heavy_atoms_only=False):
+
+    # These cause circular import errors if we put them at the top of the file
+    from ._girder import GirderClient
+    from ._calculation import GirderMolecule
+
+    # Allow the user to pass in a GirderMolecule instead of an id
+    if isinstance(mol_id1, GirderMolecule):
+        mol_id1 = mol_id1._id
+    if isinstance(mol_id2, GirderMolecule):
+        mol_id2 = mol_id2._id
+
+    if mol_id2 is None:
+        # Assume we are comparing different geometries
+        mol_id2 = mol_id1
+
+    if geometry_id1 is None:
+        cjson1 = GirderClient().get('/molecules/%s/cjson' % mol_id1)
+    else:
+        cjson1 = GirderClient().get('/molecules/%s/geometries/%s/cjson' %
+                                    (mol_id1, geometry_id1))
+
+    if geometry_id2 is None:
+        cjson2 = GirderClient().get('/molecules/%s/cjson' % mol_id2)
+    else:
+        cjson2 = GirderClient().get('/molecules/%s/geometries/%s/cjson' %
+                                    (mol_id2, geometry_id2))
+
+    coords1 = cjson1['atoms']['coords']['3d']
+    coords1_triplets = zip(coords1[0::3], coords1[1::3], coords1[2::3])
+    A = np.array([x for x in coords1_triplets])
+
+    coords2 = cjson2['atoms']['coords']['3d']
+    coords2_triplets = zip(coords2[0::3], coords2[1::3], coords2[2::3])
+    B = np.array([x for x in coords2_triplets])
+
+    if heavy_atoms_only:
+        atomic_numbers = cjson1['atoms']['elements']['number']
+        heavy_indices = [i for i, n in enumerate(atomic_numbers) if n != 1]
+
+        A = A.take(heavy_indices, 0)
+        B = B.take(heavy_indices, 0)
+
+    # Translate
+    A -= rmsd.centroid(A)
+    B -= rmsd.centroid(B)
+
+    # Rotate
+    U = rmsd.kabsch(A, B)
+    A = np.dot(A, U)
+
+    return rmsd.rmsd(A, B)

--- a/openchemistry/_utils.py
+++ b/openchemistry/_utils.py
@@ -150,7 +150,7 @@ def mol_has_3d_coords(mol):
     # This functions properly if passed None
     return cjson_has_3d_coords(mol.get('cjson'))
 
-def calculate_rmsd(mol_id1, mol_id2=None, geometry_id1=None, geometry_id2=None,
+def calculate_rmsd(mol_id, geometry_id1=None, geometry_id2=None,
                    heavy_atoms_only=False):
 
     # These cause circular import errors if we put them at the top of the file
@@ -158,26 +158,20 @@ def calculate_rmsd(mol_id1, mol_id2=None, geometry_id1=None, geometry_id2=None,
     from ._calculation import GirderMolecule
 
     # Allow the user to pass in a GirderMolecule instead of an id
-    if isinstance(mol_id1, GirderMolecule):
-        mol_id1 = mol_id1._id
-    if isinstance(mol_id2, GirderMolecule):
-        mol_id2 = mol_id2._id
-
-    if mol_id2 is None:
-        # Assume we are comparing different geometries
-        mol_id2 = mol_id1
+    if isinstance(mol_id, GirderMolecule):
+        mol_id = mol_id._id
 
     if geometry_id1 is None:
-        cjson1 = GirderClient().get('/molecules/%s/cjson' % mol_id1)
+        cjson1 = GirderClient().get('/molecules/%s/cjson' % mol_id)
     else:
         cjson1 = GirderClient().get('/molecules/%s/geometries/%s/cjson' %
-                                    (mol_id1, geometry_id1))
+                                    (mol_id, geometry_id1))
 
     if geometry_id2 is None:
-        cjson2 = GirderClient().get('/molecules/%s/cjson' % mol_id2)
+        cjson2 = GirderClient().get('/molecules/%s/cjson' % mol_id)
     else:
         cjson2 = GirderClient().get('/molecules/%s/geometries/%s/cjson' %
-                                    (mol_id2, geometry_id2))
+                                    (mol_id, geometry_id2))
 
     coords1 = cjson1['atoms']['coords']['3d']
     coords1_triplets = zip(coords1[0::3], coords1[1::3], coords1[2::3])

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         'jsonpath-rw',
         'avogadro>=1.92.1',
         'IPython',
-        'ipykernel'
+        'ipykernel',
+        'rmsd'
     ],
 
     extras_require={


### PR DESCRIPTION
This adds the ability for the user to calculate the rmsd between either
two molecules or two geometries of the same molecule, using the
[rmsd package](https://github.com/charnley/rmsd). Users can calculate
the rmsd between two molecules via `oc.calculate_rmsd(mol1, mol2)`, or
between two geometries via
`oc.calculate_rmsd(mol, geometry_id1=geometry_id1, geometry_id2=geometry_id2)`.

The added `rmsd` package seems to only add one extra dependency: `scipy`.