### PR TITLE
Print "Molecule already has 3D coords"

### DIFF
--- a/openchemistry/_visualization.py
+++ b/openchemistry/_visualization.py
@@ -123,7 +123,8 @@ class Structure(Visualization):
 
     def generate_3d(self, forcefield='mmff94', steps=100):
         if cjson_has_3d_coords(self._provider.cjson):
-            raise Exception('Molecule already has 3D coordinates')
+            print('Molecule already has 3D coordinates')
+            return
 
         id = self._provider._id
         params = {


### PR DESCRIPTION
Rather than raising an exception when the user tries to generate
3D coordinates for a molecule that already has them, print a
message instead.